### PR TITLE
allow self-signed certs, configurable server name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,14 @@ class userify(
     $self_signed = 0
 ) {
 
+  if $self_signed == 1 {
+    $insecure = '-1 -k'     # skip root CA verify, accept self-signed certs
+  } else {
+    $insecure = ''
+  }
+
   exec { 'userify':
-    command => "curl -sS \"https://dashboard.userify.com/installer.sh\" | \
+    command => "curl -sS ${insecure} \"https://${static_host}/installer.sh\" | \
       static_host=\"${static_host}\" \
       shim_host=\"${shim_host}\" \
       self_signed=${self_signed} \


### PR DESCRIPTION
When the server is provisioned with a self-signed certificate
Curl should continue rather than halting after the root CA check.

Drop back to TLS 1.0 for backward compatibility.

If set, download installer from the specified server hostname.
Default to Userify public site if server hostname is not set..