### PR TITLE
remove data_provider in metadata as its deprecated

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,5 @@
     "source": "https://github.com/fitpay/userify",
     "dependencies": [
         { "name": "puppetlabs/stdlib" }
-    ],
-    "data_provider": "hiera"
+    ]
 }


### PR DESCRIPTION
this is part of my goals to cleanup puppet warns in modules.